### PR TITLE
[UPDATE] ErrorHandler print 시 에러명과 comment 사이에 Enter 추가

### DIFF
--- a/DateWithKing/Assets/Scripts/Util/ErrorHandler.cs
+++ b/DateWithKing/Assets/Scripts/Util/ErrorHandler.cs
@@ -14,7 +14,7 @@ public static class ErrorHandler
     /// <param name="comment"> 에러와 함께 같이 출력될 코멘트(default 빈 문자열) </param>
     public static void PrintError(Define.Error error, string comment = "")
     {
-        Debug.LogError(error.ToString() + comment);
+        Debug.LogError(error.ToString() + '\n' + comment);
     }
 
     /// <summary>
@@ -25,6 +25,6 @@ public static class ErrorHandler
 
     public static void PrintWarning(Define.Warning warning, string comment = "")
     {
-        Debug.LogWarning(warning.ToString() + comment);
+        Debug.LogWarning(warning.ToString() + '\n' + comment);
     }
 }


### PR DESCRIPTION
## 🆔시스템 번호

## 🔗명세서 링크

https://www.notion.so/ErrorHandler-16d6331b128e80789d9dc02dfd99773b?pvs=4

## ❤️‍🔥구현 요구사항
기존에는 에러나 경고 출력 시 에러명/경고명(enum)에 comment가 바로 붙어 출력되었는데 둘 사이에 Enter 을 추가하여 출력