### PR TITLE
[FIX] OpenCV Temp 파일 증식 문제 해결

### DIFF
--- a/DateWithKing/Assets/Scripts/OpenCVController/OpenCVController.cs
+++ b/DateWithKing/Assets/Scripts/OpenCVController/OpenCVController.cs
@@ -110,7 +110,11 @@ public class OpenCVController : Singleton<OpenCVController>
     {
         if (pythonProcess != null && !pythonProcess.HasExited){
             InvokeDetector("End", null);
-            pythonProcess?.Kill();  // 프로세스 강제 종료
+            if (!pythonProcess.WaitForExit(5000))
+            {
+                // 3) 그래도 안 꺼지면 Kill
+                pythonProcess.Kill();
+            }
             pythonProcess?.Dispose();  // 리소스 정리
         }
     }


### PR DESCRIPTION
## 원인

종료 프로세스 시작 전에 유니티 측에서 Kill을 해서 삭제되지 않음

## 개선점?

.exe로 빌드 시에 --OneFile 대신 --OneDir로 하면 애초에 Temp 파일이 생기지 않음. 빌드하는 분 이거 참고해서 --OneDir로 빌드하시고 연락 좀.
